### PR TITLE
Fix #7: table cell reusing collection view scrolling speed

### DIFF
--- a/Table View in a Collection View/TableViewCell.swift
+++ b/Table View in a Collection View/TableViewCell.swift
@@ -13,6 +13,7 @@ extension TableViewCell {
         collectionView.delegate = dataSourceDelegate
         collectionView.dataSource = dataSourceDelegate
         collectionView.tag = row
+        collectionView.setContentOffset(collectionView.contentOffset, animated:false)
         collectionView.reloadData()
     }
 


### PR DESCRIPTION
When whipping around a collection view with many items and scrolling down the tableviewcell reuses the collection view's scroll speed.


![giphy](https://cloud.githubusercontent.com/assets/1474560/12215390/ae5cf9f2-b688-11e5-8623-d85474985057.gif)
